### PR TITLE
ci: add dist sync validation workflow

### DIFF
--- a/.github/workflows/ci-dist-sync.yml
+++ b/.github/workflows/ci-dist-sync.yml
@@ -1,0 +1,37 @@
+name: CI Dist Sync
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  dist-sync:
+    name: Verify dist files are in sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build dist files
+        run: npm run build
+
+      - name: Check dist files are in sync
+        run: |
+          if git diff --exit-code dist/; then
+            echo "dist/ files are in sync with source"
+          else
+            echo "::error::dist/ files are out of sync. Run 'npm run build' and commit the updated dist/ files."
+            exit 1
+          fi


### PR DESCRIPTION
The `dist/` files are committed to the repo but there's no CI check ensuring they stay in sync with source. This means a release could ship stale dist files if someone forgets to rebuild before merging. This workflow catches that drift automatically.